### PR TITLE
fix(key-manager-ui): 修复状态指示器默认值为 'UNTESTED'

### DIFF
--- a/js/ui/key-manager-ui.js
+++ b/js/ui/key-manager-ui.js
@@ -400,7 +400,7 @@ class KeyManagerUI {
      * @private
      */
     _updateKeyStatusIndicator(indicatorElement, status) {
-        indicatorElement.textContent = status.toUpperCase();
+        indicatorElement.textContent = status && status.toUpperCase() || 'UNTESTED'; // 默认显示 UNTESTED
         switch (status) {
             case 'valid':
                 indicatorElement.className = 'text-xs px-2 py-0.5 rounded-full font-medium bg-green-100 text-green-700';


### PR DESCRIPTION
This pull request includes a minor update to the `KeyManagerUI` class in `js/ui/key-manager-ui.js`. The change ensures that the key status indicator defaults to displaying "UNTESTED" when the `status` value is null or undefined.

* [`js/ui/key-manager-ui.js`](diffhunk://#diff-a4eeeb82269ac7113f9dcb5334c3848a7b1a91a649a08fe2ffd06ac854b7b027L403-R403): Updated the `_updateKeyStatusIndicator` method to use a fallback value of "UNTESTED" if the `status` parameter is falsy.